### PR TITLE
Remove thenable interface

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,12 +1,12 @@
 let current, batched;
 
 const sigShare = (s) => {
-  s.toJSON = s.then = s.toString = s.valueOf = () => s.value;
+  s.toJSON = s.toString = s.valueOf = () => s.value;
   return s;
 };
 
 const oShare = (s) => {
-  s.toJSON = s.then = s.toString = s.valueOf = () => s();
+  s.toJSON = s.toString = s.valueOf = () => s();
   return s;
 };
 


### PR DESCRIPTION
`.then` method has different signature than the other methods and will cause errors when used in async flows.
No other signal implementations support `.then`.